### PR TITLE
[xar] Improve bdist_xar on OS X

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,9 @@
 envlist = py27,py36
 
 [testenv]
-deps = pytest
+deps =
+  mock
+  pytest
 commands =
     pytest
     python setup.py bdist_xar

--- a/xar/commands/bdist_xar.py
+++ b/xar/commands/bdist_xar.py
@@ -179,15 +179,6 @@ class bdist_xar(Command):
         entry_point_str = "%s:%s" % (entry_point.module_name, attrs)
         xar.set_entry_point(entry_point_str)
 
-    def _add_dependencies(self, xar, dist, entry_point=None):
-        # The entry point may require extra dependencies
-        extras = entry_point.extras if entry_point else ()
-        # Add in the dependencies
-        deps = pkg_resources.working_set.resolve(dist.requires(extras=extras))
-        for dep in deps:
-            xar.add_distribution(dep)
-        return set(deps)
-
     def _build_entry_point(self, base_xar, dist, common_deps, entry_name, entry_point):
         # Clone the base xar
         xar = copy.deepcopy(base_xar)
@@ -198,6 +189,7 @@ class bdist_xar(Command):
         deps = set(pkg_resources.working_set.resolve(requires, extras=extras))
         deps -= common_deps
         for dep in deps:
+            log.info("adding dependency '%s' to xar" % dep.project_name)
             xar.add_distribution(dep)
         # Set the entry point
         self._set_entry_point(xar, entry_point)
@@ -216,6 +208,7 @@ class bdist_xar(Command):
             # Add in the dependencies common to each entry_point
             deps = set(pkg_resources.working_set.resolve(dist.requires()))
             for dep in deps:
+                log.info("adding dependency '%s' to xar" % dep.project_name)
                 xar.add_distribution(dep)
             # Set the interpreter to the current python interpreter
             if self.interpreter is not None:

--- a/xar/py_util_test.py
+++ b/xar/py_util_test.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from xar import py_util, xar_test_helpers
+
+
+class PyUtilTest(xar_test_helpers.XarTestCase):
+    def test_environment_python_interpreter(self):
+        interpreter = py_util.environment_python_interpreter()
+        self.assertTrue(interpreter.startswith("/usr/bin/env"))
+
+    def test_wheel_determine_kind_normal(self):
+        distribution = mock.MagicMock(egg_info='xar-18.6.11-py3-none-any.whl')
+        wheel = py_util.Wheel(distribution=distribution)
+        lib = "/usr/lib/python/site-packages"
+        paths = {
+            "purelib": lib,
+            "platlib": lib,
+            "headers": "/usr/include/xar",
+            "scripts": "/usr/bin",
+            "data": "/usr",
+        }
+        k, p = wheel._determine_kind(lib, paths, paths, lib + "/tmp")
+        self.assertTrue(k == "purelib" or k == "platlib")
+        self.assertEqual(p, lib)
+        k, p = wheel._determine_kind(lib, paths, paths, "/usr/none")
+        self.assertEqual(k, "data")
+        self.assertEqual(p, "/usr")
+        k, p = wheel._determine_kind(lib, paths, paths, "/usr/bin/make_xar")
+        self.assertEqual(k, "scripts")
+        self.assertEqual(p, "/usr/bin")
+        k, p = wheel._determine_kind(lib, paths, paths, "/usr/include/xar/x")
+        self.assertEqual(k, "headers")
+        self.assertEqual(p, "/usr/include/xar")
+
+    def test_wheel_determine_kind_mac(self):
+        distribution = mock.MagicMock(egg_info='xar-18.6.11-py3-none-any.whl')
+        wheel = py_util.Wheel(distribution=distribution)
+        root = "/usr"
+        lib = "/usr/lib/python/site-packages"
+        paths = {
+            "purelib": lib,
+            "platlib": lib,
+            "headers": "/bad/prefix/include/xar",
+            "scripts": "/bad/prefix/bin",
+            "data": "/bad/prefix",
+        }
+        k, p = wheel._determine_kind(lib, paths, paths, lib + "/tmp")
+        self.assertTrue(k == "purelib" or k == "platlib")
+        self.assertEqual(p, lib)
+        k, p = wheel._determine_kind(lib, paths, paths, "/usr/none")
+        self.assertEqual(k, "data")
+        self.assertEqual(p, "/usr")
+        k, p = wheel._determine_kind(lib, paths, paths, "/usr/bin/make_xar")
+        self.assertEqual(k, "scripts")
+        self.assertEqual(p, "/usr/bin")
+        k, p = wheel._determine_kind(lib, paths, paths, "/usr/include/xar/x")
+        self.assertEqual(k, "headers")
+        self.assertEqual(p, "/usr/include/xar")

--- a/xar/xar_builder.py
+++ b/xar/xar_builder.py
@@ -383,7 +383,8 @@ class PythonXarBuilder(XarBuilder):
         # We only support wheels.
         if not distribution.has_metadata(py_util.Wheel.WHEEL_INFO):
             raise self.InvalidDistributionError(
-                "'%s' is not a wheel!" % distribution.location
+                "'%s' is not a wheel! It might be an egg, try reinstalling as "
+                "a wheel." % distribution.project_name
             )
         wheel = py_util.Wheel(distribution=distribution)
         sys_paths = wheel.sys_install_paths()

--- a/xar/xar_util_test.py
+++ b/xar/xar_util_test.py
@@ -162,10 +162,6 @@ class XarUtilTest(xar_test_helpers.XarTestCase):
         with clone.open("r+t") as f:
             self.assertEqual(data, f.read())
 
-    def test_environment_python_interpreter(self):
-        interpreter = py_util.environment_python_interpreter()
-        self.assertTrue(interpreter.startswith("/usr/bin/env"))
-
     def make_test_skeleton(self):
         "Make a simple tree of test files"
         srcdir = tempfile.mkdtemp()


### PR DESCRIPTION
Summary:
The install paths on OS X with Python installed with Homebrew are not accurate. The `site-packages` is a symlink pointing to the right place, but the scripts/headers install locations are wrong. If we fail to find the package in `src_paths`, use heuristics to guess the kind and prefix. This shouldn't affect any platforms that were already working, since it only happens if normal method fails.

Test Plan:
OS X:
```
pip3.6 install .
python3.6 /path/to/xar/setup.py bdist_xar
/path/to/xar/dist/make_xar.xar --help

pip3.6 install /path/to/jupyter/notebook/
python3.6 /path/to/jupyter/notebook/setup.py bdist_xar --console-scripts=jupyter-notebook
/path/to/xar/dist/jupyter-notebook
```

OS X & Linux:
```
python3.6 -m venv /tmp/xar
/tmp/xar/pip install /path/to/xar
/tmp/xar/python /path/to/xar/setup.py bdist_xar
/path/to/xar/dist/make_xar.xar --help

/tmp/xar/pip install /path/to/jupyter/notebook/
/tmp/xar/python /path/to/jupyter/notebook/setup.py bdist_xar --console-scripts=jupyter-notebook
/path/to/xar/dist/jupyter-notebook
```