### PR TITLE
[xar] Fix open source

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         # a workaround. (grep setuptools>=34.1 to see issue)
         # https://github.com/pypa/setuptools/commit/8c1f489f09434f42080397367b6491e75f64d838  # noqa: E501
         "setuptools>=34.1",
-        "wheel",
+        "wheel<=0.31.1",
     ],
     test_requires=["mock", "pytest"],
     classifiers=[

--- a/xar/py_util.py
+++ b/xar/py_util.py
@@ -47,6 +47,13 @@ def parse_entry_point(entry_point):
     else:
         return (module, None)
 
+def get_python_main(directory):
+    """Returns the python __main__ from a directory (if it exists)."""
+    main = os.path.join(directory, "__main__")
+    main_exists = any(os.path.exists(main + ext) for ext in PYTHON_EXTS)
+    if main_exists:
+        return "__main__"
+    return None
 
 def extract_python_archive_info(archive):
     """
@@ -103,6 +110,7 @@ def is_python_version(interpreter, version_info):
 import sys
 print('.'.join(str(x) for x in sys.version_info))
     """
+    assert interpreter is not None
     with tempfile.NamedTemporaryFile("w+t", delete=False) as f:
         f.write(VERSION_INFO_MAIN)
         f.flush()

--- a/xar/xar_builder_test.py
+++ b/xar/xar_builder_test.py
@@ -6,10 +6,19 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import contextlib
 import copy
 import os
+import subprocess
+import tempfile
+import unittest
 
-from xar import xar_builder, xar_test_helpers, xar_util
+try:
+    import zipapp
+except ImportError:
+    zipapp = None
+
+from xar import make_xar, xar_builder, xar_test_helpers, xar_util
 
 
 class XarBuilderTest(xar_test_helpers.XarTestCase):
@@ -212,3 +221,64 @@ class XarBuilderTest(xar_test_helpers.XarTestCase):
         )
         self.assertNotEqual(other._sort_file.name(), self.xar_builder._sort_file.name())
         other.delete()
+
+
+class MakeXarTest(unittest.TestCase):
+    @contextlib.contextmanager
+    def make_test_directory(self):
+        try:
+            dir = tempfile.mkdtemp()
+            with open(os.path.join(dir, "__main__.py"), "w") as f:
+                f.write("print('python')")
+            with open(os.path.join(dir, "other.py"), "w") as f:
+                f.write("print('other')")
+            with open(os.path.join(dir, "__main__.sh"), "w") as f:
+                f.write("#!/bin/sh\necho shell")
+            with tempfile.NamedTemporaryFile("w") as xarfile:
+                yield xarfile.name, dir
+        finally:
+            xar_util.safe_rmtree(dir)
+
+    def check_xar(self, xarfile):
+        return subprocess.check_output([xarfile]).strip()
+
+    def test_make_python_xar_from_directory(self):
+        with self.make_test_directory() as (xar, dir):
+            args = [
+                "--output", xar,
+                "--python", dir
+            ]
+            make_xar.main(args)
+            self.assertEqual(self.check_xar(xar), b"python")
+            args += ["--python-entry-point", "other"]
+            make_xar.main(args)
+            self.assertEqual(self.check_xar(xar), b"other")
+
+    def test_make_python_xar_from_archive(self):
+        if zipapp is None:
+            return
+        with self.make_test_directory() as (xar, dir):
+            with tempfile.NamedTemporaryFile("w") as zip:
+                zipapp.create_archive(dir, zip.name)
+                args = [
+                    "--output", xar,
+                    "--python", zip.name
+                ]
+                make_xar.main(args)
+                self.assertEqual(self.check_xar(xar), b"python")
+                args += ["--python-entry-point", "other"]
+                make_xar.main(args)
+                self.assertEqual(self.check_xar(xar), b"other")
+
+    def test_make_raw_xar(self):
+        with self.make_test_directory() as (xar, dir):
+            args = [
+                "--output", xar,
+                "--raw", dir,
+            ]
+            make_xar.main(args)
+            with self.assertRaises(OSError):
+                self.check_xar(xar)
+            args += ["--raw-executable", "__main__.sh"]
+            make_xar.main(args)
+            self.assertEqual(self.check_xar(xar), b"shell")


### PR DESCRIPTION
* We have to limit to `wheel<=0.31.1`, since they removed the public API.
  We will eventually have to copy what we use into the repo to remove this.
* Fix `make_xar` bugs.
* Add a sorely missing test cases for `make_xar`.

Fixes #20 and fixes #21.