### PR TITLE
Add GitHub Action to release to PyPI

### DIFF
--- a/.github/actions/workflows/pypi_upload.yml
+++ b/.github/actions/workflows/pypi_upload.yml
@@ -1,0 +1,31 @@
+name: pypi_upload
+
+on:
+  release:
+    types: created
+
+jobs:
+  build:
+    name: PyPI Upload
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+
+      - name: Install latest pip, setuptools, twine + wheel
+        run: |
+          python -m pip install --upgrade pip setuptools twine wheel
+
+      - name: Build wheels
+        run: |
+          python setup.py bdist_wheel
+          python setup.py sdist
+
+      - name: Upload to PyPI via Twine
+        env:
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          twine upload --verbose -u '__token__' dist/*


### PR DESCRIPTION
- On a GitHub release creation Github actions will build + upload versions of xar

Addresses making releases happen so we don't get so stale again as reported in #43