### PR TITLE
Add support for macfuse as the backend on macOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(xar)
 
 # Use modern C++ for everything, instruct clang (if used) to generate the
 # compile_commands database.
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 

--- a/xar/XarMacOS.cpp
+++ b/xar/XarMacOS.cpp
@@ -56,7 +56,7 @@ void tools::xar::close_non_std_fds() {
 // change a lot.
 bool tools::xar::is_squashfs_mounted(const struct statfs& buf) {
   auto fsname = std::string{buf.f_fstypename};
-  return fsname == "osxfuse" || fsname == "osxfusefs";
+  return fsname == "osxfuse" || fsname == "osxfusefs" || fsname == "macfuse";
 }
 
 bool tools::xar::fuse_allows_visible_mounts(std::string fuse_conf_path) {

--- a/xar/clean_xar_mounts/src/main.rs
+++ b/xar/clean_xar_mounts/src/main.rs
@@ -456,7 +456,7 @@ fn should_unmount(
 ) -> Result<ShouldUnmountResult> {
     // Only consider certain mount types.
     match mount.fstype.as_str() {
-        "fuse.squashfuse" | "fuse.squashfuse_ll" | "osxfusefs" | "osxfuse" => {}
+        "fuse.squashfuse" | "fuse.squashfuse_ll" | "osxfusefs" | "osxfuse" | "macfuse" => {}
         _ => return Ok(ShouldUnmountResult::new(false, None)),
     }
     info!(

--- a/xar/deprecated/mount_xar.py
+++ b/xar/deprecated/mount_xar.py
@@ -135,7 +135,7 @@ def flock_with_timeout(lock_fd, lock_type, timeout_sec):
 # (should_unmount, lock_fd) of whether to unmount and a descriptor
 # holding a flock (which should be closed after the unmount).
 def should_unmount(devname, mountpath, fstype, timeout):
-    if fstype not in ("fuse.squashfuse", "fuse.squashfuse_ll", "osxfusefs", "osxfuse"):
+    if fstype not in ("fuse.squashfuse", "fuse.squashfuse_ll", "osxfusefs", "osxfuse", "macfuse"):
         return (False, None)
 
     logging.debug("Considering %s (%s)..." % (mountpath, fstype))


### PR DESCRIPTION
This PR does two things:
1. Switch the CMAKE_CXX_STANDARD to 17 so this can be compiled in macOS
2. Add support for macfuse (the successor to osxfuse)

## CMAKE_CXX_STANDARD

The recent macOS SDKs require this, otherwise the compile fails with something like this:

```
mseeger@mseeger-mbp build % make xarexec_fuse
[ 20%] Building CXX object CMakeFiles/XarHelperLib.dir/xar/XarHelpers.cpp.o
In file included from /Users/mseeger/workspace/xar/xar/XarHelpers.cpp:7:
/Users/mseeger/workspace/xar/xar/XarHelpers.h:155:6: error: no template named 'optional' in namespace 'std'
std::optional<ino_t> read_sysfs_cgroup_inode(const char *filename);
~~~~~^
/Users/mseeger/workspace/xar/xar/XarHelpers.cpp:14:6: error: no template named 'optional' in namespace 'std'
std::optional<std::string> read_file_prefix(const char *filename,
~~~~~^
/Users/mseeger/workspace/xar/xar/XarHelpers.cpp:18:17: error: no member named 'nullopt' in namespace 'std'
    return std::nullopt;
           ~~~~~^
/Users/mseeger/workspace/xar/xar/XarHelpers.cpp:25:17: error: no member named 'nullopt' in namespace 'std'
    return std::nullopt;
           ~~~~~^
/Users/mseeger/workspace/xar/xar/XarHelpers.cpp:30:17: error: no member named 'nullopt' in namespace 'std'
    return std::nullopt;
           ~~~~~^
/Users/mseeger/workspace/xar/xar/XarHelpers.cpp:33:10: error: no viable conversion from returned value of type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') to function return type 'int'
  return buf;
         ^~~
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:875:5: note: candidate function
    operator __self_view() const _NOEXCEPT { return __self_view(data(), size()); }
    ^
/Users/mseeger/workspace/xar/xar/XarHelpers.cpp:93:6: error: no template named 'optional' in namespace 'std'
std::optional<ino_t> read_sysfs_cgroup_inode(const char *filename) {
~~~~~^
/Users/mseeger/workspace/xar/xar/XarHelpers.cpp:96:17: error: no member named 'nullopt' in namespace 'std'
    return std::nullopt;
           ~~~~~^
/Users/mseeger/workspace/xar/xar/XarHelpers.cpp:100:17: error: no member named 'nullopt' in namespace 'std'
    return std::nullopt;
           ~~~~~^
/Users/mseeger/workspace/xar/xar/XarHelpers.cpp:107:17: error: no member named 'nullopt' in namespace 'std'
    return std::nullopt;
           ~~~~~^
/Users/mseeger/workspace/xar/xar/XarHelpers.cpp:125:15: error: no member named 'nullopt' in namespace 'std'
  return std::nullopt;
         ~~~~~^
11 errors generated.
make[3]: *** [CMakeFiles/XarHelperLib.dir/xar/XarHelpers.cpp.o] Error 1
make[2]: *** [CMakeFiles/XarHelperLib.dir/all] Error 2
make[1]: *** [CMakeFiles/xarexec_fuse.dir/rule] Error 2
make: *** [xarexec_fuse] Error 2
```

## Macfuse

As you can see on https://osxfuse.github.io/, osxfuse is now macfuse.

The mount looks like this:
```
squashfuse_ll@macfuse0 on /System/Volumes/Data/mnt/xarfuse/uid-0/1d33f049 (macfuse, synchronous)
```

Adding 'macfuse' as a valid filesystem type fixes the 'wait forever for it to mount' issue that macfuse otherwise causes

## Testing

I scp'ed the resulting binary to an existing host that had macfuse installed and confirmed that it did indeed correctly mount + execute a xar file (as opposed to just hang + getting a timeout)