### PR TITLE
Add Logging file to xarlib_srcs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ option(XAR_BUILD_TESTS "Compile XAR tests" off)
 option(XAR_INSTALL "Enable installation of XAR" on)
 
 # xar helpers (easier to build as a library)
-set(xarlib_srcs xar/XarHelpers.h xar/XarHelpers.cpp)
+set(xarlib_srcs xar/Logging.h xar/Logging.cpp xar/XarHelpers.h xar/XarHelpers.cpp)
 if(APPLE)
     list(APPEND xarlib_srcs xar/XarMacOS.cpp)
 elseif(UNIX AND NOT APPLE)  # otherwise known as "Linux"


### PR DESCRIPTION
I have a feeling the open source build has
been broken (at least for MacOS) since
https://github.com/facebookincubator/xar/commit/a4c59465d7550c0e26041114d213076bc9ad49ac

I was getting a linking error against Logging.h,
repro'd with both clang and gcc. Explicitly
adding that dependency to the `xarlib_srcs` set has
the binary compiling successfully for me now.