### PR TITLE
[xar] Fix CircleCI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
   jobs:
     build:
       docker:
-        - image: circleci/python:3.7.3-stretch
+        - image: cimg/python:3.7
       steps:
         - checkout
         - run:
@@ -10,7 +10,7 @@
             command: |
               sudo apt-get update
               sudo apt-get install -y cmake
-              sudo pip install tox
+              pip install tox
         - run:
             name: Installing zstd
             working_directory: ~/zstd
@@ -22,8 +22,8 @@
             name: Installing squashfs-tools
             working_directory: ~/squashfs-tools
             command: |
-              wget https://github.com/plougher/squashfs-tools/archive/fb33dfc32b131a1162dcf0e35bd88254ae10e265.tar.gz -O - | tar -xz
-              cd squashfs-tools-fb33dfc32b131a1162dcf0e35bd88254ae10e265/squashfs-tools
+              wget https://github.com/plougher/squashfs-tools/archive/refs/tags/4.5.1.tar.gz -O - | tar -xz
+              cd squashfs-tools-4.5.1/squashfs-tools
               make ZSTD_SUPPORT=1 && sudo make install
         - run:
             name: Installing gtest


### PR DESCRIPTION
Right now CircleCI tests are failing very early on, as the version of CMake in
the container image used doesn't want to compile C++17 (I think?).

This change moves towards getting good signal back from CircleCI.

* Updates the CircleCI container image used to `cimg/python:3.7`
  * This also resolves the CircleCI deprecation issue (https://circleci.com/docs/2.0/next-gen-migration-guide/)
  * Don't run pip with sudo (it's not in root's PATH in the new image)
* Bumps squashfs-tools to the latest release to compile on glibc>=2.25
  * See https://github.com/plougher/squashfs-tools/commit/968aa53dd6d2c0831a9af01873441767c06b88d0

## Testing
I tested this (with the changes in #48 cherry-picked in to get things to compile cleanly) using `circleci local execute`.

At this point, the C++ test suite builds and runs cleanly, but there's one test failure in the Python test suite.

### C++
```
====>> Test
  #!/bin/bash -eo pipefail
make test
tox

Running tests...
Test project /home/circleci/project
    Start 1: XarHelpers.SplitTest
1/7 Test #1: XarHelpers.SplitTest ...................   Passed    0.04 sec
    Start 2: XarHelpers.PartialSplitTest
2/7 Test #2: XarHelpers.PartialSplitTest ............   Passed    0.04 sec
    Start 3: XarHelpers.JoinTest
3/7 Test #3: XarHelpers.JoinTest ....................   Passed    0.04 sec
    Start 4: XarHelpers.FuseConfTest
4/7 Test #4: XarHelpers.FuseConfTest ................   Passed    0.03 sec
    Start 5: XarHelpers.DefaultMountRootsTest
5/7 Test #5: XarHelpers.DefaultMountRootsTest .......   Passed    0.03 sec
    Start 6: XarHelpers.FindCgroupInodeTest
6/7 Test #6: XarHelpers.FindCgroupInodeTest .........   Passed    0.03 sec
    Start 7: XarHelpers.SerializeHeaderAsJSONTest
7/7 Test #7: XarHelpers.SerializeHeaderAsJSONTest ...   Passed    0.03 sec

100% tests passed, 0 tests failed out of 7

Total Test time (real) =   0.28 sec
```

### Python
```
============================= test session starts ==============================
platform linux -- Python 3.7.13, pytest-7.1.1, pluggy-1.0.0
cachedir: .tox/py37/.pytest_cache
rootdir: /home/circleci/project
collected 31 items

xar/tests/make_xar_test.py ...                                           [  9%]
xar/tests/pip_installer_test.py ..                                       [ 16%]
xar/tests/py_util_test.py ........F                                      [ 45%]
xar/tests/xar_builder_test.py .........                                  [ 74%]
xar/tests/xar_util_test.py ........                                      [100%]

=================================== FAILURES ===================================
___________________ PyUtilTest.test_wheel_sys_install_paths ____________________

self = <xar.tests.py_util_test.PyUtilTest testMethod=test_wheel_sys_install_paths>

    def test_wheel_sys_install_paths(self):
        print(TESTWHEEL)
        wheel = py_util.Wheel(location=TESTWHEEL)
>       sys_paths = wheel.sys_install_paths()

xar/tests/py_util_test.py:138:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
xar/py_util.py:274: in sys_install_paths
    sys_paths = paths.get_install_paths(self.name)
xar/vendor/wheel/paths.py:29: in get_install_paths
    i = get_install_command(name)
xar/vendor/wheel/paths.py:16: in get_install_command
    i = install.install(d)
.tox/py37/lib/python3.7/site-packages/setuptools/__init__.py:174: in __init__
    super().__init__(dist)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <distutils.command.install.install object at 0x40049b5890>
dist = <setuptools.dist.Distribution object at 0x4005fd1790>

    def __init__(self, dist):
        """Create and initialize a new Command object.  Most importantly,
        invokes the 'initialize_options()' method, which is the real
        initializer and depends on the actual command being
        instantiated.
        """
        # late import because of mutual dependence between these classes
        from distutils.dist import Distribution

        if not isinstance(dist, Distribution):
>           raise TypeError("dist must be a Distribution instance")
E           TypeError: dist must be a Distribution instance

.tox/py37/lib/python3.7/site-packages/setuptools/_distutils/cmd.py:57: TypeError
```