### PR TITLE
Ignore Cargo's lock and ccls cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,9 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Rust Cargo lock
+Cargo.lock
+
+# CCLS cache
+.ccls-cache


### PR DESCRIPTION
While working on Cargo builds I noticed that there is additional files that are here and that could be ignored.